### PR TITLE
Add shape property to Button components

### DIFF
--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/Button.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/Button.kt
@@ -1,22 +1,34 @@
 package com.vini.designsystemsdui
 
-fun button(text: String, horizontalFillType: String = "Max", isEnabled: Boolean = true) =
+fun button(
+    text: String,
+    horizontalFillType: String = "Max",
+    isEnabled: Boolean = true,
+    shape: String = "Small",
+) =
     ComponentUtil.component(
         type = "button",
         properties = listOf(
             ComponentUtil.property("text", text),
             ComponentUtil.property("enabled", isEnabled),
             ComponentUtil.property("horizontalFillType", horizontalFillType),
+            ComponentUtil.property("shape", shape),
         )
     )
 
-fun outlinedButton(text: String, horizontalFillType: String = "Max", isEnabled: Boolean = true) =
+fun outlinedButton(
+    text: String,
+    horizontalFillType: String = "Max",
+    isEnabled: Boolean = true,
+    shape: String = "Small",
+) =
     ComponentUtil.component(
         type = "outlinedButton",
         properties = listOf(
             ComponentUtil.property("text", text),
             ComponentUtil.property("enabled", isEnabled),
             ComponentUtil.property("horizontalFillType", horizontalFillType),
+            ComponentUtil.property("shape", shape),
         )
     )
 

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/components/button/ButtonComponent.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/components/button/ButtonComponent.kt
@@ -56,6 +56,6 @@ data class ButtonComponent(
 @Composable
 private fun Preview() {
     SdUiComponentPreview(
-        button(text = "salve", shape = "Small")
+        button(text = "salve", shape = "Circle")
     )
 }

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/components/button/ButtonComponent.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/components/button/ButtonComponent.kt
@@ -12,6 +12,8 @@ import com.example.serverdriveui.ui.component.components.BaseComponent
 import com.example.serverdriveui.ui.component.manager.SdUiComponentPreview
 import com.example.serverdriveui.ui.component.properties.EnabledComponentProperty
 import com.example.serverdriveui.ui.component.properties.EnabledProperty
+import com.example.serverdriveui.ui.component.properties.ShapeComponentProperty
+import com.example.serverdriveui.ui.component.properties.ShapeProperty
 import com.example.serverdriveui.ui.component.properties.TextComponentProperty
 import com.example.serverdriveui.ui.component.properties.TextProperty
 import com.example.serverdriveui.ui.state.ComponentStateManager
@@ -27,7 +29,8 @@ data class ButtonComponent(
     private val actionParser: ActionParser,
 ) : BaseComponent(model, properties, stateManager, validatorParser, actionParser),
     TextComponentProperty by TextProperty(properties, stateManager),
-    EnabledComponentProperty by EnabledProperty(properties, stateManager) {
+    EnabledComponentProperty by EnabledProperty(properties, stateManager),
+    ShapeComponentProperty by ShapeProperty(properties, stateManager) {
 
     @Composable
     override fun getInternalComponent(
@@ -37,6 +40,7 @@ data class ButtonComponent(
         Button(
             enabled = getEnabled(),
             modifier = modifier,
+            shape = getShape(),
             onClick = { actions["OnClick"]?.execute(navController) },
             content = { Text(getText()) },
         )
@@ -52,6 +56,6 @@ data class ButtonComponent(
 @Composable
 private fun Preview() {
     SdUiComponentPreview(
-        button(text = "salve")
+        button(text = "salve", shape = "Small")
     )
 }

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/components/button/ElevatedButtonComponent.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/components/button/ElevatedButtonComponent.kt
@@ -10,6 +10,8 @@ import com.example.serverdriveui.ui.action.manager.ActionParser
 import com.example.serverdriveui.ui.component.components.BaseComponent
 import com.example.serverdriveui.ui.component.properties.EnabledComponentProperty
 import com.example.serverdriveui.ui.component.properties.EnabledProperty
+import com.example.serverdriveui.ui.component.properties.ShapeComponentProperty
+import com.example.serverdriveui.ui.component.properties.ShapeProperty
 import com.example.serverdriveui.ui.component.properties.TextComponentProperty
 import com.example.serverdriveui.ui.component.properties.TextProperty
 import com.example.serverdriveui.ui.state.ComponentStateManager
@@ -28,7 +30,8 @@ data class ElevatedButtonComponent(
     private val actionParser: ActionParser,
 ) : BaseComponent(model, properties, stateManager, validatorParser, actionParser),
     TextComponentProperty by TextProperty(properties, stateManager),
-    EnabledComponentProperty by EnabledProperty(properties, stateManager) {
+    EnabledComponentProperty by EnabledProperty(properties, stateManager),
+    ShapeComponentProperty by ShapeProperty(properties, stateManager) {
 
     @Composable
     override fun getInternalComponent(
@@ -39,6 +42,7 @@ data class ElevatedButtonComponent(
             ElevatedButton(
                 enabled = isEnabled,
                 modifier = modifier,
+                shape = getShape(),
                 onClick = {
                     actions["OnClick"]?.execute(navController)
                 },

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/components/button/OutlinedButtonComponent.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/components/button/OutlinedButtonComponent.kt
@@ -12,6 +12,8 @@ import com.example.serverdriveui.ui.component.components.BaseComponent
 import com.example.serverdriveui.ui.component.manager.SdUiComponentPreview
 import com.example.serverdriveui.ui.component.properties.EnabledComponentProperty
 import com.example.serverdriveui.ui.component.properties.EnabledProperty
+import com.example.serverdriveui.ui.component.properties.ShapeComponentProperty
+import com.example.serverdriveui.ui.component.properties.ShapeProperty
 import com.example.serverdriveui.ui.component.properties.TextComponentProperty
 import com.example.serverdriveui.ui.component.properties.TextProperty
 import com.example.serverdriveui.ui.state.ComponentStateManager
@@ -31,7 +33,8 @@ data class OutlinedButtonComponent(
     private val actionParser: ActionParser,
 ) : BaseComponent(model, properties, stateManager, validatorParser, actionParser),
     TextComponentProperty by TextProperty(properties, stateManager),
-    EnabledComponentProperty by EnabledProperty(properties, stateManager) {
+    EnabledComponentProperty by EnabledProperty(properties, stateManager),
+    ShapeComponentProperty by ShapeProperty(properties, stateManager) {
 
     @Composable
     override fun getInternalComponent(
@@ -42,6 +45,7 @@ data class OutlinedButtonComponent(
         OutlinedButton(
             enabled = isEnabled,
             modifier = modifier,
+            shape = getShape(),
             onClick = {
                 actions["OnClick"]?.execute(navController)
             },
@@ -58,6 +62,6 @@ data class OutlinedButtonComponent(
 @Composable
 private fun Preview() {
     SdUiComponentPreview(
-        outlinedButton(text = "salve")
+        outlinedButton(text = "salve", shape = "Small")
     )
 }

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/ShapeProperty.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/ShapeProperty.kt
@@ -1,0 +1,44 @@
+package com.example.serverdriveui.ui.component.properties
+
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.dp
+import com.example.serverdriveui.service.model.PropertyModel
+import com.example.serverdriveui.ui.state.ComponentStateManager
+import com.example.serverdriveui.util.JsonUtil.asString
+
+interface ShapeComponentProperty {
+    @Composable
+    fun getShape(): Shape
+    fun setShape(shape: ShapeOptions)
+}
+
+class ShapeProperty(
+    private val properties: Map<String, PropertyModel>,
+    private val stateManager: ComponentStateManager,
+) : ShapeComponentProperty,
+    BasePropertyData<String>(
+        stateManager = stateManager,
+        properties = properties,
+        propertyName = "shape",
+        transformToData = { it?.asString() },
+        defaultPropertyValue = ShapeOptions.None.id,
+    ) {
+    @Composable
+    override fun getShape() = getValue().toOption().shape
+
+    override fun setShape(shape: ShapeOptions) = setValue(shape.id)
+}
+
+enum class ShapeOptions(val id: String, val shape: Shape) {
+    None("", RoundedCornerShape(0.dp)),
+    Small("Small", RoundedCornerShape(4.dp)),
+    Medium("Medium", RoundedCornerShape(8.dp)),
+    Large("Large", RoundedCornerShape(16.dp)),
+    Circle("Circle", CircleShape),
+}
+
+private fun String?.toOption(): ShapeOptions =
+    ShapeOptions.entries.firstOrNull { it.id == this } ?: ShapeOptions.None

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/ShapeProperty.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/ShapeProperty.kt
@@ -24,7 +24,7 @@ class ShapeProperty(
         properties = properties,
         propertyName = "shape",
         transformToData = { it?.asString() },
-        defaultPropertyValue = ShapeOptions.None.id,
+        defaultPropertyValue = ShapeOptions.Circle.id,
     ) {
     @Composable
     override fun getShape() = getValue().toOption().shape
@@ -33,7 +33,7 @@ class ShapeProperty(
 }
 
 enum class ShapeOptions(val id: String, val shape: Shape) {
-    None("", RoundedCornerShape(0.dp)),
+    None("None", RoundedCornerShape(0.dp)),
     Small("Small", RoundedCornerShape(4.dp)),
     Medium("Medium", RoundedCornerShape(8.dp)),
     Large("Large", RoundedCornerShape(16.dp)),


### PR DESCRIPTION
## Summary
- add `ShapeProperty` to manage different button shapes
- support shape property in `ButtonComponent` and variants
- expose shape parameter in SDUI button builders

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aef7646ac832eb04e607576764a13