### PR TITLE
Move property enums to PropertyOptions

### DIFF
--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/PropertyOptions.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/PropertyOptions.kt
@@ -1,0 +1,112 @@
+package com.vini.designsystemsdui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.vini.designsystem.compose.textfield.MaskVisualTransformation
+
+/**
+ * Central place for all option enums used by component properties.
+ */
+object PropertyOptions {
+    enum class AlignmentOptions(val id: String, val alignment: Alignment) {
+        TopStart("TopStart", Alignment.TopStart),
+        TopCenter("TopCenter", Alignment.TopCenter),
+        TopEnd("TopEnd", Alignment.TopEnd),
+        CenterStart("CenterStart", Alignment.CenterStart),
+        Center("Center", Alignment.Center),
+        CenterEnd("CenterEnd", Alignment.CenterEnd),
+        BottomStart("BottomStart", Alignment.BottomStart),
+        BottomCenter("BottomCenter", Alignment.BottomCenter),
+        BottomEnd("BottomEnd", Alignment.BottomEnd),
+    }
+
+    enum class HorizontalAlignmentOptions(val id: String, val alignment: Alignment.Horizontal) {
+        Center("Center", Alignment.CenterHorizontally),
+        Start("Start", Alignment.Start),
+        End("End", Alignment.End),
+    }
+
+    enum class HorizontalArrangementOptions(val id: String, val arrangement: Arrangement.Horizontal) {
+        Start("Start", Arrangement.Start),
+        End("End", Arrangement.End),
+        Center("Center", Arrangement.Center),
+        SpaceBetween("SpaceBetween", Arrangement.SpaceBetween),
+        SpaceAround("SpaceAround", Arrangement.SpaceAround),
+    }
+
+    enum class HorizontalFillTypeOption(val id: String, val modifier: Modifier) {
+        Max("Max", Modifier.fillMaxWidth()),
+        Half("Half", Modifier.fillMaxWidth(.5f)),
+        Quarter("Quarter", Modifier.fillMaxWidth(.25f)),
+        Wrap("Wrap", Modifier.wrapContentWidth()),
+        None("", Modifier),
+    }
+
+    enum class KeyboardOptionsOption(val id: String, val keyboardOptions: KeyboardOptions) {
+        Default("Default", KeyboardOptions.Default),
+        Number("Number", KeyboardOptions(keyboardType = KeyboardType.Number)),
+        Phone("Phone", KeyboardOptions(keyboardType = KeyboardType.Phone)),
+        Password("Password", KeyboardOptions(keyboardType = KeyboardType.Password)),
+    }
+
+    enum class ShapeOptions(val id: String, val shape: Shape) {
+        None("None", RoundedCornerShape(0.dp)),
+        Small("Small", RoundedCornerShape(4.dp)),
+        Medium("Medium", RoundedCornerShape(8.dp)),
+        Large("Large", RoundedCornerShape(16.dp)),
+        Circle("Circle", CircleShape),
+    }
+
+    enum class TextAlignOption(val id: String, val textAlign: TextAlign) {
+        Start("Start", TextAlign.Start),
+        Center("Center", TextAlign.Center),
+        End("End", TextAlign.End),
+    }
+
+    enum class VerticalAlignmentOption(val id: String, val verticalAlignment: Alignment.Vertical) {
+        Top("Top", Alignment.Top),
+        Center("Center", Alignment.CenterVertically),
+        Bottom("Bottom", Alignment.Bottom),
+    }
+
+    enum class VerticalFillTypeOption(val id: String, val modifier: Modifier) {
+        Max("Max", Modifier.fillMaxHeight()),
+        Half("Half", Modifier.fillMaxHeight(.5f)),
+        Quarter("Quarter", Modifier.fillMaxHeight(.25f)),
+        Wrap("Wrap", Modifier.wrapContentHeight()),
+        None("", Modifier),
+    }
+
+    enum class VisualTransformationOption(val id: String, val visualTransformation: VisualTransformation) {
+        None("None", VisualTransformation.None),
+        Password("Password", PasswordVisualTransformation()),
+        Phone(
+            "Phone",
+            MaskVisualTransformation(
+                mask = "## #####-####",
+                toIgnore = '#'
+            )
+        ),
+        Document(
+            "Documento.CPF",
+            MaskVisualTransformation(
+                mask = "###.###.###-##",
+                toIgnore = '#'
+            )
+        ),
+    }
+}

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/ContentAlignmentProperty.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/ContentAlignmentProperty.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Alignment
 import com.example.serverdriveui.service.model.PropertyModel
 import com.example.serverdriveui.ui.state.ComponentStateManager
 import com.example.serverdriveui.util.JsonUtil.asString
+import com.vini.designsystemsdui.PropertyOptions.AlignmentOptions
 
 interface ContentAlignmentComponentProperty {
 
@@ -35,14 +36,3 @@ class ContentAlignmentProperty(
 private fun String?.toOptions() =
     AlignmentOptions.entries.firstOrNull { it.id == this } ?: AlignmentOptions.TopStart
 
-enum class AlignmentOptions(val id: String, val alignment: Alignment) {
-    TopStart("TopStart", Alignment.TopStart),
-    TopCenter("TopCenter", Alignment.TopCenter),
-    TopEnd("TopEnd", Alignment.TopEnd),
-    CenterStart("CenterStart", Alignment.CenterStart),
-    Center("Center", Alignment.Center),
-    CenterEnd("CenterEnd", Alignment.CenterEnd),
-    BottomStart("BottomStart", Alignment.BottomStart),
-    BottomCenter("BottomCenter", Alignment.BottomCenter),
-    BottomEnd("BottomEnd", Alignment.BottomEnd),
-}

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/HorizontalAlignmentProperty.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/HorizontalAlignmentProperty.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Alignment
 import com.example.serverdriveui.service.model.PropertyModel
 import com.example.serverdriveui.ui.state.ComponentStateManager
 import com.example.serverdriveui.util.JsonUtil.asString
+import com.vini.designsystemsdui.PropertyOptions.HorizontalAlignmentOptions
 
 class HorizontalAlignmentProperty(
     private val properties: Map<String, PropertyModel>,
@@ -22,12 +23,6 @@ class HorizontalAlignmentProperty(
     override fun getHorizontalAlignment() = getValue().toOption().alignment
 
     override fun setHorizontalAlignment(value: HorizontalAlignmentOptions) = setValue(value.id)
-}
-
-enum class HorizontalAlignmentOptions(val id: String, val alignment: Alignment.Horizontal) {
-    Center("Center", Alignment.CenterHorizontally),
-    Start("Start", Alignment.Start),
-    End("End", Alignment.End),
 }
 
 private fun String?.toOption() =

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/HorizontalArrangementProperty.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/HorizontalArrangementProperty.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import com.example.serverdriveui.service.model.PropertyModel
 import com.example.serverdriveui.ui.state.ComponentStateManager
 import com.example.serverdriveui.util.JsonUtil.asString
+import com.vini.designsystemsdui.PropertyOptions.HorizontalArrangementOptions
 
 class HorizontalArrangementProperty(
     private val properties: Map<String, PropertyModel>,
@@ -21,14 +22,6 @@ class HorizontalArrangementProperty(
     @Composable
     override fun getHorizontalArrangement() = getValue().toOption().arrangement
     override fun setHorizontalArrangement(value: HorizontalArrangementOptions) = setValue(value.id)
-}
-
-enum class HorizontalArrangementOptions(val id: String, val arrangement: Arrangement.Horizontal) {
-    Start("Start", Arrangement.Start),
-    End("End", Arrangement.End),
-    Center("Center", Arrangement.Center),
-    SpaceBetween("SpaceBetween", Arrangement.SpaceBetween),
-    SpaceAround("SpaceAround", Arrangement.SpaceAround),
 }
 
 private fun String?.toOption() =

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/HorizontalFillTypeProperty.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/HorizontalFillTypeProperty.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import com.example.serverdriveui.service.model.PropertyModel
 import com.example.serverdriveui.ui.state.ComponentStateManager
 import com.example.serverdriveui.util.JsonUtil.asString
+import com.vini.designsystemsdui.PropertyOptions.HorizontalFillTypeOption
 
 data class HorizontalFillTypeProperty(
     private val properties: Map<String, PropertyModel>,
@@ -23,14 +24,6 @@ data class HorizontalFillTypeProperty(
     override val horizontalFillTypeModifier: Modifier
         @Composable
         get() = getValue().toOptions().modifier
-}
-
-enum class HorizontalFillTypeOption(val id: String, val modifier: Modifier) {
-    Max("Max", Modifier.fillMaxWidth()),
-    Half("Half", Modifier.fillMaxWidth(.5f)),
-    Quarter("Quarter", Modifier.fillMaxWidth(.25f)),
-    Wrap("Wrap", Modifier.wrapContentWidth()),
-    None("", Modifier),
 }
 
 private fun String?.toOptions(): HorizontalFillTypeOption =

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/KeyboardOptionsProperty.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/KeyboardOptionsProperty.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import com.example.serverdriveui.service.model.PropertyModel
 import com.example.serverdriveui.ui.state.ComponentStateManager
 import com.example.serverdriveui.util.JsonUtil.asString
+import com.vini.designsystemsdui.PropertyOptions.KeyboardOptionsOption
 
 class KeyboardOptionsProperty(
     private val properties: Map<String, PropertyModel>,
@@ -23,13 +24,6 @@ class KeyboardOptionsProperty(
     override fun getKeyboardOptions() = getValue().toOption().keyboardOptions
 
     override fun setKeyboardOptions(keyboardOptions: KeyboardOptionsOption) = setValue(keyboardOptions.id)
-}
-
-enum class KeyboardOptionsOption(val id: String, val keyboardOptions: KeyboardOptions) {
-    Default("Default", KeyboardOptions.Default),
-    Number("Number", KeyboardOptions(keyboardType = KeyboardType.Number)),
-    Phone("Phone", KeyboardOptions(keyboardType = KeyboardType.Phone)),
-    Password("Password", KeyboardOptions(keyboardType = KeyboardType.Password)),
 }
 
 private fun String?.toOption() =

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/ShapeProperty.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/ShapeProperty.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.unit.dp
 import com.example.serverdriveui.service.model.PropertyModel
 import com.example.serverdriveui.ui.state.ComponentStateManager
 import com.example.serverdriveui.util.JsonUtil.asString
+import com.vini.designsystemsdui.PropertyOptions.ShapeOptions
 
 interface ShapeComponentProperty {
     @Composable
@@ -30,14 +31,6 @@ class ShapeProperty(
     override fun getShape() = getValue().toOption().shape
 
     override fun setShape(shape: ShapeOptions) = setValue(shape.id)
-}
-
-enum class ShapeOptions(val id: String, val shape: Shape) {
-    None("None", RoundedCornerShape(0.dp)),
-    Small("Small", RoundedCornerShape(4.dp)),
-    Medium("Medium", RoundedCornerShape(8.dp)),
-    Large("Large", RoundedCornerShape(16.dp)),
-    Circle("Circle", CircleShape),
 }
 
 private fun String?.toOption(): ShapeOptions =

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/TextAlignProperty.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/TextAlignProperty.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.text.style.TextAlign
 import com.example.serverdriveui.service.model.PropertyModel
 import com.example.serverdriveui.ui.state.ComponentStateManager
 import com.example.serverdriveui.util.JsonUtil.asString
+import com.vini.designsystemsdui.PropertyOptions.TextAlignOption
 
 class TextAlignProperty(
     private val properties: Map<String, PropertyModel>,
@@ -22,12 +23,6 @@ class TextAlignProperty(
     override fun getTextAlign() = getValue().toTextAlign().textAlign
 
     override fun setTextAlign(textAlign: TextAlignOption) = setValue(textAlign.id)
-}
-
-enum class TextAlignOption(val id: String, val textAlign: TextAlign) {
-    Start("Start", TextAlign.Start),
-    Center("Center", TextAlign.Center),
-    End("End", TextAlign.End),
 }
 
 private fun String?.toTextAlign() =

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/VerticalAlignmentProperty.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/VerticalAlignmentProperty.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Alignment
 import com.example.serverdriveui.service.model.PropertyModel
 import com.example.serverdriveui.ui.state.ComponentStateManager
 import com.example.serverdriveui.util.JsonUtil.asString
+import com.vini.designsystemsdui.PropertyOptions.VerticalAlignmentOption
 
 class VerticalAlignmentProperty(
     private val properties: Map<String, PropertyModel>,
@@ -22,12 +23,6 @@ class VerticalAlignmentProperty(
     override fun getVerticalAlignment() = getValue().toOption().verticalAlignment
 
     override fun setVerticalAlignment(value: VerticalAlignmentOption) = setValue(value.id)
-}
-
-enum class VerticalAlignmentOption(val id: String, val verticalAlignment: Alignment.Vertical) {
-    Top("Top", Alignment.Top),
-    Center("Center", Alignment.CenterVertically),
-    Bottom("Bottom", Alignment.Bottom),
 }
 
 private fun String?.toOption() =

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/VerticalFillTypeProperty.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/VerticalFillTypeProperty.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import com.example.serverdriveui.service.model.PropertyModel
 import com.example.serverdriveui.ui.state.ComponentStateManager
 import com.example.serverdriveui.util.JsonUtil.asString
+import com.vini.designsystemsdui.PropertyOptions.VerticalFillTypeOption
 
 data class VerticalFillTypeProperty(
     private val properties: Map<String, PropertyModel>,
@@ -22,14 +23,6 @@ data class VerticalFillTypeProperty(
     override val verticalFillTypeModifier: Modifier
         @Composable
         get() = getValue().toOption().modifier
-}
-
-enum class VerticalFillTypeOption(val id: String, val modifier: Modifier) {
-    Max("Max", Modifier.Companion.fillMaxHeight()),
-    Half("Half", Modifier.Companion.fillMaxHeight(.5f)),
-    Quarter("Quarter", Modifier.Companion.fillMaxHeight(.25f)),
-    Wrap("Wrap", Modifier.wrapContentHeight()),
-    None("", Modifier)
 }
 
 private fun String?.toOption() =

--- a/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/VisualTransformationProperty.kt
+++ b/ServerDriveUi/src/main/java/com/example/serverdriveui/ui/component/properties/VisualTransformationProperty.kt
@@ -4,10 +4,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import com.example.serverdriveui.service.model.PropertyModel
-import com.example.serverdriveui.ui.component.properties.VisualTransformationOption.None
 import com.example.serverdriveui.ui.state.ComponentStateManager
 import com.example.serverdriveui.util.JsonUtil.asString
 import com.vini.designsystem.compose.textfield.MaskVisualTransformation
+import com.vini.designsystemsdui.PropertyOptions.VisualTransformationOption
 
 class VisualTransformationProperty(
     private val properties: Map<String, PropertyModel>,
@@ -18,7 +18,7 @@ class VisualTransformationProperty(
         properties = properties,
         propertyName = "visualTransformation",
         transformToData = { it?.asString() },
-        defaultPropertyValue = None.id,
+        defaultPropertyValue = VisualTransformationOption.None.id,
     ) {
 
     @Composable
@@ -30,29 +30,7 @@ class VisualTransformationProperty(
 
 private fun String?.toOption() =
     VisualTransformationOption.entries.firstOrNull { it.id == this }
-        ?: None
-
-enum class VisualTransformationOption(
-    val id: String,
-    val visualTransformation: VisualTransformation,
-) {
-    None("None", VisualTransformation.None),
-    Password("Password", PasswordVisualTransformation()),
-    Phone(
-        "Phone",
-        MaskVisualTransformation(
-            mask = "## #####-####",
-            toIgnore = '#'
-        )
-    ),
-    Document(
-        "Documento.CPF",
-        MaskVisualTransformation(
-            mask = "###.###.###-##",
-            toIgnore = '#'
-        )
-    ),
-}
+        ?: VisualTransformationOption.None
 
 interface VisualTransformationComponentProperty {
     @Composable


### PR DESCRIPTION
## Summary
- centralize options enums in new `PropertyOptions` under the `designsystemsdui` package
- reference these enums in property implementations

## Testing
- `./gradlew tasks --all`
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b82175ae4832e82806a4144a0ab63