### PR TITLE
feat: add missing design system components

### DIFF
--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/Blank.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/Blank.kt
@@ -1,0 +1,16 @@
+package com.vini.designsystemsdui.component
+
+import com.vini.designsystemsdui.Action
+import com.vini.designsystemsdui.Component
+import com.vini.designsystemsdui.ComponentUtil
+import com.vini.designsystemsdui.Validator
+
+fun blank(
+    actions: List<Action> = emptyList(),
+    validators: List<Validator> = emptyList(),
+): Component = ComponentUtil.component(
+    "blank",
+    emptyList(),
+    actions = actions,
+    validators = validators,
+)

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/Box.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/Box.kt
@@ -1,0 +1,46 @@
+package com.vini.designsystemsdui.component
+
+import com.vini.designsystemsdui.Action
+import com.vini.designsystemsdui.Component
+import com.vini.designsystemsdui.ComponentUtil
+import com.vini.designsystemsdui.Validator
+import com.vini.designsystemsdui.property.ContentAlignmentProperty
+import com.vini.designsystemsdui.property.HeightProperty
+import com.vini.designsystemsdui.property.HorizontalFillTypeProperty
+import com.vini.designsystemsdui.property.PaddingHorizontalProperty
+import com.vini.designsystemsdui.property.PaddingVerticalProperty
+import com.vini.designsystemsdui.property.VerticalFillTypeProperty
+import com.vini.designsystemsdui.property.VisibilityProperty
+import com.vini.designsystemsdui.property.WeightProperty
+import com.vini.designsystemsdui.property.WidthProperty
+
+fun box(
+    components: List<Component> = emptyList(),
+    contentAlignment: ContentAlignmentProperty = ContentAlignmentProperty(),
+    horizontalFillType: HorizontalFillTypeProperty = HorizontalFillTypeProperty(),
+    verticalFillType: VerticalFillTypeProperty = VerticalFillTypeProperty(),
+    paddingVertical: PaddingVerticalProperty = PaddingVerticalProperty(),
+    paddingHorizontal: PaddingHorizontalProperty = PaddingHorizontalProperty(),
+    height: HeightProperty? = null,
+    width: WidthProperty? = null,
+    weight: WeightProperty? = null,
+    visibility: VisibilityProperty = VisibilityProperty(),
+    actions: List<Action> = emptyList(),
+    validators: List<Validator> = emptyList(),
+) = ComponentUtil.component(
+    "box",
+    listOfNotNull(
+        contentAlignment.build(),
+        horizontalFillType.build(),
+        verticalFillType.build(),
+        paddingVertical.build(),
+        paddingHorizontal.build(),
+        height?.build(),
+        width?.build(),
+        weight?.build(),
+        visibility.build(),
+    ),
+    components = components,
+    actions = actions,
+    validators = validators,
+)

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/Dialog.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/Dialog.kt
@@ -1,0 +1,32 @@
+package com.vini.designsystemsdui.component
+
+import com.vini.designsystemsdui.Action
+import com.vini.designsystemsdui.Component
+import com.vini.designsystemsdui.ComponentUtil
+import com.vini.designsystemsdui.Validator
+import com.vini.designsystemsdui.property.ShouldShowProperty
+import com.vini.designsystemsdui.property.VisibilityProperty
+
+fun dialog(
+    shouldShow: ShouldShowProperty = ShouldShowProperty(),
+    icon: List<Component> = emptyList(),
+    title: List<Component> = emptyList(),
+    text: List<Component> = emptyList(),
+    visibility: VisibilityProperty = VisibilityProperty(),
+    actions: List<Action> = emptyList(),
+    validators: List<Validator> = emptyList(),
+): Component = ComponentUtil.component(
+    "dialog",
+    listOf(
+        shouldShow.build(),
+        visibility.build(),
+    ),
+    components = emptyList(),
+    customComponents = arrayOf(
+        "icon" to icon,
+        "title" to title,
+        "text" to text,
+    ),
+    actions = actions,
+    validators = validators,
+)

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/HorizontalPager.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/HorizontalPager.kt
@@ -1,0 +1,31 @@
+package com.vini.designsystemsdui.component
+
+import com.vini.designsystemsdui.Action
+import com.vini.designsystemsdui.Component
+import com.vini.designsystemsdui.ComponentUtil
+import com.vini.designsystemsdui.Validator
+import com.vini.designsystemsdui.property.ContentPaddingProperty
+import com.vini.designsystemsdui.property.CurrentPageProperty
+import com.vini.designsystemsdui.property.VerticalAlignmentProperty
+import com.vini.designsystemsdui.property.VisibilityProperty
+
+fun horizontalPager(
+    components: List<Component> = emptyList(),
+    currentPage: CurrentPageProperty = CurrentPageProperty(),
+    contentPadding: ContentPaddingProperty = ContentPaddingProperty(),
+    verticalAlignment: VerticalAlignmentProperty = VerticalAlignmentProperty(),
+    visibility: VisibilityProperty = VisibilityProperty(),
+    actions: List<Action> = emptyList(),
+    validators: List<Validator> = emptyList(),
+) = ComponentUtil.component(
+    "horizontalPager",
+    listOf(
+        currentPage.build(),
+        contentPadding.build(),
+        verticalAlignment.build(),
+        visibility.build(),
+    ),
+    components = components,
+    actions = actions,
+    validators = validators,
+)

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/LazyRow.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/LazyRow.kt
@@ -1,0 +1,49 @@
+package com.vini.designsystemsdui.component
+
+import com.vini.designsystemsdui.Action
+import com.vini.designsystemsdui.Component
+import com.vini.designsystemsdui.ComponentUtil
+import com.vini.designsystemsdui.Validator
+import com.vini.designsystemsdui.property.HeightProperty
+import com.vini.designsystemsdui.property.HorizontalArrangementProperty
+import com.vini.designsystemsdui.property.HorizontalFillTypeProperty
+import com.vini.designsystemsdui.property.PaddingHorizontalProperty
+import com.vini.designsystemsdui.property.PaddingVerticalProperty
+import com.vini.designsystemsdui.property.VerticalAlignmentProperty
+import com.vini.designsystemsdui.property.VerticalFillTypeProperty
+import com.vini.designsystemsdui.property.VisibilityProperty
+import com.vini.designsystemsdui.property.WeightProperty
+import com.vini.designsystemsdui.property.WidthProperty
+
+fun lazyRow(
+    components: List<Component> = emptyList(),
+    horizontalArrangement: HorizontalArrangementProperty = HorizontalArrangementProperty(),
+    verticalAlignment: VerticalAlignmentProperty = VerticalAlignmentProperty(),
+    horizontalFillType: HorizontalFillTypeProperty = HorizontalFillTypeProperty(),
+    verticalFillType: VerticalFillTypeProperty = VerticalFillTypeProperty(),
+    paddingVertical: PaddingVerticalProperty = PaddingVerticalProperty(),
+    paddingHorizontal: PaddingHorizontalProperty = PaddingHorizontalProperty(),
+    height: HeightProperty? = null,
+    width: WidthProperty? = null,
+    weight: WeightProperty? = null,
+    visibility: VisibilityProperty = VisibilityProperty(),
+    actions: List<Action> = emptyList(),
+    validators: List<Validator> = emptyList(),
+) = ComponentUtil.component(
+    "lazyRow",
+    listOfNotNull(
+        horizontalArrangement.build(),
+        verticalAlignment.build(),
+        horizontalFillType.build(),
+        verticalFillType.build(),
+        paddingVertical.build(),
+        paddingHorizontal.build(),
+        height?.build(),
+        width?.build(),
+        weight?.build(),
+        visibility.build(),
+    ),
+    components = components,
+    actions = actions,
+    validators = validators,
+)

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/LottieAnimation.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/LottieAnimation.kt
@@ -1,0 +1,29 @@
+package com.vini.designsystemsdui.component
+
+import com.vini.designsystemsdui.Action
+import com.vini.designsystemsdui.Component
+import com.vini.designsystemsdui.ComponentUtil
+import com.vini.designsystemsdui.Validator
+import com.vini.designsystemsdui.property.HeightProperty
+import com.vini.designsystemsdui.property.LottieAnimationDataProperty
+import com.vini.designsystemsdui.property.VisibilityProperty
+import com.vini.designsystemsdui.property.WidthProperty
+
+fun lottieAnimation(
+    animationData: LottieAnimationDataProperty = LottieAnimationDataProperty(""),
+    height: HeightProperty? = null,
+    width: WidthProperty? = null,
+    visibility: VisibilityProperty = VisibilityProperty(),
+    actions: List<Action> = emptyList(),
+    validators: List<Validator> = emptyList(),
+): Component = ComponentUtil.component(
+    "lottie",
+    listOfNotNull(
+        animationData.build(),
+        height?.build(),
+        width?.build(),
+        visibility.build(),
+    ),
+    actions = actions,
+    validators = validators,
+)

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/SnackBar.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/SnackBar.kt
@@ -1,0 +1,23 @@
+package com.vini.designsystemsdui.component
+
+import com.vini.designsystemsdui.Action
+import com.vini.designsystemsdui.Component
+import com.vini.designsystemsdui.ComponentUtil
+import com.vini.designsystemsdui.Validator
+import com.vini.designsystemsdui.property.TextProperty
+import com.vini.designsystemsdui.property.VisibilityProperty
+
+fun snackBar(
+    text: TextProperty = TextProperty(""),
+    visibility: VisibilityProperty = VisibilityProperty(),
+    actions: List<Action> = emptyList(),
+    validators: List<Validator> = emptyList(),
+): Component = ComponentUtil.component(
+    "snackBar",
+    listOf(
+        text.build(),
+        visibility.build(),
+    ),
+    actions = actions,
+    validators = validators,
+)

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/TextInput.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/TextInput.kt
@@ -1,0 +1,69 @@
+package com.vini.designsystemsdui.component
+
+import com.vini.designsystemsdui.Action
+import com.vini.designsystemsdui.Component
+import com.vini.designsystemsdui.ComponentUtil
+import com.vini.designsystemsdui.Validator
+import com.vini.designsystemsdui.property.ErrorMessageProperty
+import com.vini.designsystemsdui.property.ErrorProperty
+import com.vini.designsystemsdui.property.HeightProperty
+import com.vini.designsystemsdui.property.HorizontalAlignmentProperty
+import com.vini.designsystemsdui.property.HorizontalFillTypeProperty
+import com.vini.designsystemsdui.property.IsEnabledProperty
+import com.vini.designsystemsdui.property.KeyboardOptionsProperty
+import com.vini.designsystemsdui.property.LabelProperty
+import com.vini.designsystemsdui.property.PaddingHorizontalProperty
+import com.vini.designsystemsdui.property.PaddingVerticalProperty
+import com.vini.designsystemsdui.property.TextProperty
+import com.vini.designsystemsdui.property.VerticalAlignmentProperty
+import com.vini.designsystemsdui.property.VerticalFillTypeProperty
+import com.vini.designsystemsdui.property.VisibilityProperty
+import com.vini.designsystemsdui.property.VisualTransformationProperty
+import com.vini.designsystemsdui.property.WidthProperty
+
+fun textInput(
+    text: TextProperty = TextProperty(""),
+    label: LabelProperty = LabelProperty(""),
+    isEnabled: IsEnabledProperty = IsEnabledProperty(),
+    visualTransformation: VisualTransformationProperty = VisualTransformationProperty(),
+    keyboardOptions: KeyboardOptionsProperty = KeyboardOptionsProperty(),
+    error: ErrorProperty = ErrorProperty(),
+    errorMessage: ErrorMessageProperty = ErrorMessageProperty(),
+    verticalAlignment: VerticalAlignmentProperty = VerticalAlignmentProperty(),
+    horizontalAlignment: HorizontalAlignmentProperty = HorizontalAlignmentProperty(),
+    horizontalFillType: HorizontalFillTypeProperty = HorizontalFillTypeProperty(),
+    verticalFillTypeOption: VerticalFillTypeProperty = VerticalFillTypeProperty(),
+    paddingVertical: PaddingVerticalProperty = PaddingVerticalProperty(),
+    paddingHorizontal: PaddingHorizontalProperty = PaddingHorizontalProperty(),
+    height: HeightProperty? = null,
+    width: WidthProperty? = null,
+    visibility: VisibilityProperty = VisibilityProperty(),
+    actions: List<Action> = emptyList(),
+    validators: List<Validator> = emptyList(),
+    trailingIcon: List<Component> = emptyList(),
+) = ComponentUtil.component(
+    type = "textInput",
+    properties = listOfNotNull(
+        text.build(),
+        isEnabled.build(),
+        label.build(),
+        visualTransformation.build(),
+        keyboardOptions.build(),
+        error.build(),
+        errorMessage.build(),
+        verticalAlignment.build(),
+        horizontalAlignment.build(),
+        horizontalFillType.build(),
+        verticalFillTypeOption.build(),
+        paddingVertical.build(),
+        paddingHorizontal.build(),
+        height?.build(),
+        width?.build(),
+        visibility.build(),
+    ),
+    actions = actions,
+    validators = validators,
+    customComponents = arrayOf(
+        "trailingIcon" to trailingIcon,
+    ),
+)

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/ContentAlignmentProperty.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/ContentAlignmentProperty.kt
@@ -1,0 +1,8 @@
+package com.vini.designsystemsdui.property
+
+import com.vini.designsystemsdui.property.options.AlignmentOptions
+
+class ContentAlignmentProperty(
+    val alignment: AlignmentOptions = AlignmentOptions.TopStart,
+    val id: String? = null,
+) : BaseComponentProperty.StringComponentProperty("contentAlignment", alignment.name, id)

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/ContentPaddingProperty.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/ContentPaddingProperty.kt
@@ -1,0 +1,6 @@
+package com.vini.designsystemsdui.property
+
+class ContentPaddingProperty(
+    val padding: Int = 0,
+    val id: String? = null,
+) : BaseComponentProperty.NumberComponentProperty("contentPadding", padding, id)

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/CurrentPageProperty.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/CurrentPageProperty.kt
@@ -1,0 +1,6 @@
+package com.vini.designsystemsdui.property
+
+class CurrentPageProperty(
+    val page: Int = 0,
+    val id: String? = null,
+) : BaseComponentProperty.NumberComponentProperty("currentPage", page, id)

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/LottieAnimationDataProperty.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/LottieAnimationDataProperty.kt
@@ -1,0 +1,6 @@
+package com.vini.designsystemsdui.property
+
+class LottieAnimationDataProperty(
+    val animation: String,
+    val id: String? = null,
+) : BaseComponentProperty.StringComponentProperty("animation", animation, id)


### PR DESCRIPTION
## Summary
- add basic components such as Box, LazyRow and others missing in design system
- implement required properties for new component types
- support additional UI constructs like horizontal pager and lottie animations

## Testing
- `./gradlew :DesignSystemSdUi:test`

------
https://chatgpt.com/codex/tasks/task_e_688da3518ab0832eab1a33dd4597f4da