### PR TITLE
feat: add missing sdui components

### DIFF
--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/CreatePassword.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/CreatePassword.kt
@@ -1,0 +1,51 @@
+package com.vini.designsystemsdui.component
+
+import com.vini.designsystemsdui.Action
+import com.vini.designsystemsdui.Component
+import com.vini.designsystemsdui.ComponentUtil
+import com.vini.designsystemsdui.Validator
+import com.vini.designsystemsdui.property.HeightProperty
+import com.vini.designsystemsdui.property.HorizontalAlignmentProperty
+import com.vini.designsystemsdui.property.HorizontalFillTypeProperty
+import com.vini.designsystemsdui.property.PaddingHorizontalProperty
+import com.vini.designsystemsdui.property.PaddingVerticalProperty
+import com.vini.designsystemsdui.property.TextProperty
+import com.vini.designsystemsdui.property.ValidPasswordProperty
+import com.vini.designsystemsdui.property.VerticalAlignmentProperty
+import com.vini.designsystemsdui.property.VerticalFillTypeProperty
+import com.vini.designsystemsdui.property.VisibilityProperty
+import com.vini.designsystemsdui.property.WidthProperty
+
+fun createPassword(
+    text: TextProperty = TextProperty(""),
+    validPassword: ValidPasswordProperty = ValidPasswordProperty(false),
+    verticalAlignment: VerticalAlignmentProperty = VerticalAlignmentProperty(),
+    horizontalAlignment: HorizontalAlignmentProperty = HorizontalAlignmentProperty(),
+    horizontalFillType: HorizontalFillTypeProperty = HorizontalFillTypeProperty(),
+    verticalFillType: VerticalFillTypeProperty = VerticalFillTypeProperty(),
+    paddingVertical: PaddingVerticalProperty = PaddingVerticalProperty(),
+    paddingHorizontal: PaddingHorizontalProperty = PaddingHorizontalProperty(),
+    height: HeightProperty? = null,
+    width: WidthProperty? = null,
+    visibility: VisibilityProperty = VisibilityProperty(),
+    actions: List<Action> = emptyList(),
+    validators: List<Validator> = emptyList(),
+): Component = ComponentUtil.component(
+    "createPassword",
+    listOfNotNull(
+        text.build(),
+        validPassword.build(),
+        verticalAlignment.build(),
+        horizontalAlignment.build(),
+        horizontalFillType.build(),
+        verticalFillType.build(),
+        paddingVertical.build(),
+        paddingHorizontal.build(),
+        height?.build(),
+        width?.build(),
+        visibility.build(),
+    ),
+    actions = actions,
+    validators = validators,
+)
+

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/GoogleMaps.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/GoogleMaps.kt
@@ -1,0 +1,45 @@
+package com.vini.designsystemsdui.component
+
+import com.vini.designsystemsdui.Action
+import com.vini.designsystemsdui.Component
+import com.vini.designsystemsdui.ComponentUtil
+import com.vini.designsystemsdui.Validator
+import com.vini.designsystemsdui.property.HeightProperty
+import com.vini.designsystemsdui.property.HorizontalAlignmentProperty
+import com.vini.designsystemsdui.property.HorizontalFillTypeProperty
+import com.vini.designsystemsdui.property.PaddingHorizontalProperty
+import com.vini.designsystemsdui.property.PaddingVerticalProperty
+import com.vini.designsystemsdui.property.VerticalAlignmentProperty
+import com.vini.designsystemsdui.property.VerticalFillTypeProperty
+import com.vini.designsystemsdui.property.VisibilityProperty
+import com.vini.designsystemsdui.property.WidthProperty
+
+fun googleMaps(
+    verticalAlignment: VerticalAlignmentProperty = VerticalAlignmentProperty(),
+    horizontalAlignment: HorizontalAlignmentProperty = HorizontalAlignmentProperty(),
+    horizontalFillType: HorizontalFillTypeProperty = HorizontalFillTypeProperty(),
+    verticalFillType: VerticalFillTypeProperty = VerticalFillTypeProperty(),
+    paddingVertical: PaddingVerticalProperty = PaddingVerticalProperty(),
+    paddingHorizontal: PaddingHorizontalProperty = PaddingHorizontalProperty(),
+    height: HeightProperty? = null,
+    width: WidthProperty? = null,
+    visibility: VisibilityProperty = VisibilityProperty(),
+    actions: List<Action> = emptyList(),
+    validators: List<Validator> = emptyList(),
+): Component = ComponentUtil.component(
+    "googleMaps",
+    listOfNotNull(
+        verticalAlignment.build(),
+        horizontalAlignment.build(),
+        horizontalFillType.build(),
+        verticalFillType.build(),
+        paddingVertical.build(),
+        paddingHorizontal.build(),
+        height?.build(),
+        width?.build(),
+        visibility.build(),
+    ),
+    actions = actions,
+    validators = validators,
+)
+

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/HorizontalDivider.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/HorizontalDivider.kt
@@ -1,0 +1,48 @@
+package com.vini.designsystemsdui.component
+
+import com.vini.designsystemsdui.Action
+import com.vini.designsystemsdui.Component
+import com.vini.designsystemsdui.ComponentUtil
+import com.vini.designsystemsdui.Validator
+import com.vini.designsystemsdui.property.HeightProperty
+import com.vini.designsystemsdui.property.HorizontalAlignmentProperty
+import com.vini.designsystemsdui.property.HorizontalFillTypeProperty
+import com.vini.designsystemsdui.property.PaddingHorizontalProperty
+import com.vini.designsystemsdui.property.PaddingVerticalProperty
+import com.vini.designsystemsdui.property.SizeProperty
+import com.vini.designsystemsdui.property.VerticalAlignmentProperty
+import com.vini.designsystemsdui.property.VerticalFillTypeProperty
+import com.vini.designsystemsdui.property.VisibilityProperty
+import com.vini.designsystemsdui.property.WidthProperty
+
+fun horizontalDivider(
+    size: SizeProperty? = null,
+    verticalAlignment: VerticalAlignmentProperty = VerticalAlignmentProperty(),
+    horizontalAlignment: HorizontalAlignmentProperty = HorizontalAlignmentProperty(),
+    horizontalFillType: HorizontalFillTypeProperty = HorizontalFillTypeProperty(),
+    verticalFillType: VerticalFillTypeProperty = VerticalFillTypeProperty(),
+    paddingVertical: PaddingVerticalProperty = PaddingVerticalProperty(),
+    paddingHorizontal: PaddingHorizontalProperty = PaddingHorizontalProperty(),
+    height: HeightProperty? = null,
+    width: WidthProperty? = null,
+    visibility: VisibilityProperty = VisibilityProperty(),
+    actions: List<Action> = emptyList(),
+    validators: List<Validator> = emptyList(),
+): Component = ComponentUtil.component(
+    "horizontalDivider",
+    listOfNotNull(
+        size?.build(),
+        verticalAlignment.build(),
+        horizontalAlignment.build(),
+        horizontalFillType.build(),
+        verticalFillType.build(),
+        paddingVertical.build(),
+        paddingHorizontal.build(),
+        height?.build(),
+        width?.build(),
+        visibility.build(),
+    ),
+    actions = actions,
+    validators = validators,
+)
+

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/SdUi.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/SdUi.kt
@@ -1,0 +1,63 @@
+package com.vini.designsystemsdui.component
+
+import com.vini.designsystemsdui.Action
+import com.vini.designsystemsdui.Component
+import com.vini.designsystemsdui.ComponentUtil
+import com.vini.designsystemsdui.Validator
+import com.vini.designsystemsdui.property.CurrentScreenProperty
+import com.vini.designsystemsdui.property.FlowIdentifierProperty
+import com.vini.designsystemsdui.property.HeightProperty
+import com.vini.designsystemsdui.property.HorizontalAlignmentProperty
+import com.vini.designsystemsdui.property.HorizontalFillTypeProperty
+import com.vini.designsystemsdui.property.PaddingHorizontalProperty
+import com.vini.designsystemsdui.property.PaddingVerticalProperty
+import com.vini.designsystemsdui.property.RequestUpdateProperty
+import com.vini.designsystemsdui.property.ScreenDataProperty
+import com.vini.designsystemsdui.property.StageIdentifierProperty
+import com.vini.designsystemsdui.property.VerticalAlignmentProperty
+import com.vini.designsystemsdui.property.VerticalFillTypeProperty
+import com.vini.designsystemsdui.property.VisibilityProperty
+import com.vini.designsystemsdui.property.WidthProperty
+import kotlinx.serialization.json.JsonObject
+
+fun sdUi(
+    components: List<Component> = emptyList(),
+    flow: FlowIdentifierProperty = FlowIdentifierProperty(""),
+    stage: StageIdentifierProperty = StageIdentifierProperty(""),
+    screenData: ScreenDataProperty = ScreenDataProperty(JsonObject(emptyMap())),
+    currentScreen: CurrentScreenProperty = CurrentScreenProperty(""),
+    requestUpdate: RequestUpdateProperty = RequestUpdateProperty(false),
+    verticalAlignment: VerticalAlignmentProperty = VerticalAlignmentProperty(),
+    horizontalAlignment: HorizontalAlignmentProperty = HorizontalAlignmentProperty(),
+    horizontalFillType: HorizontalFillTypeProperty = HorizontalFillTypeProperty(),
+    verticalFillType: VerticalFillTypeProperty = VerticalFillTypeProperty(),
+    paddingVertical: PaddingVerticalProperty = PaddingVerticalProperty(),
+    paddingHorizontal: PaddingHorizontalProperty = PaddingHorizontalProperty(),
+    height: HeightProperty? = null,
+    width: WidthProperty? = null,
+    visibility: VisibilityProperty = VisibilityProperty(),
+    actions: List<Action> = emptyList(),
+    validators: List<Validator> = emptyList(),
+): Component = ComponentUtil.component(
+    "sdui",
+    listOfNotNull(
+        flow.build(),
+        stage.build(),
+        screenData.build(),
+        currentScreen.build(),
+        requestUpdate.build(),
+        verticalAlignment.build(),
+        horizontalAlignment.build(),
+        horizontalFillType.build(),
+        verticalFillType.build(),
+        paddingVertical.build(),
+        paddingHorizontal.build(),
+        height?.build(),
+        width?.build(),
+        visibility.build(),
+    ),
+    components = components,
+    actions = actions,
+    validators = validators,
+)
+

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/VerticalDivider.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/component/VerticalDivider.kt
@@ -1,0 +1,48 @@
+package com.vini.designsystemsdui.component
+
+import com.vini.designsystemsdui.Action
+import com.vini.designsystemsdui.Component
+import com.vini.designsystemsdui.ComponentUtil
+import com.vini.designsystemsdui.Validator
+import com.vini.designsystemsdui.property.HeightProperty
+import com.vini.designsystemsdui.property.HorizontalAlignmentProperty
+import com.vini.designsystemsdui.property.HorizontalFillTypeProperty
+import com.vini.designsystemsdui.property.PaddingHorizontalProperty
+import com.vini.designsystemsdui.property.PaddingVerticalProperty
+import com.vini.designsystemsdui.property.SizeProperty
+import com.vini.designsystemsdui.property.VerticalAlignmentProperty
+import com.vini.designsystemsdui.property.VerticalFillTypeProperty
+import com.vini.designsystemsdui.property.VisibilityProperty
+import com.vini.designsystemsdui.property.WidthProperty
+
+fun verticalDivider(
+    size: SizeProperty? = null,
+    verticalAlignment: VerticalAlignmentProperty = VerticalAlignmentProperty(),
+    horizontalAlignment: HorizontalAlignmentProperty = HorizontalAlignmentProperty(),
+    horizontalFillType: HorizontalFillTypeProperty = HorizontalFillTypeProperty(),
+    verticalFillType: VerticalFillTypeProperty = VerticalFillTypeProperty(),
+    paddingVertical: PaddingVerticalProperty = PaddingVerticalProperty(),
+    paddingHorizontal: PaddingHorizontalProperty = PaddingHorizontalProperty(),
+    height: HeightProperty? = null,
+    width: WidthProperty? = null,
+    visibility: VisibilityProperty = VisibilityProperty(),
+    actions: List<Action> = emptyList(),
+    validators: List<Validator> = emptyList(),
+): Component = ComponentUtil.component(
+    "verticalDivider",
+    listOfNotNull(
+        size?.build(),
+        verticalAlignment.build(),
+        horizontalAlignment.build(),
+        horizontalFillType.build(),
+        verticalFillType.build(),
+        paddingVertical.build(),
+        paddingHorizontal.build(),
+        height?.build(),
+        width?.build(),
+        visibility.build(),
+    ),
+    actions = actions,
+    validators = validators,
+)
+

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/CurrentScreenProperty.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/CurrentScreenProperty.kt
@@ -1,0 +1,7 @@
+package com.vini.designsystemsdui.property
+
+class CurrentScreenProperty(
+    val currentScreen: String,
+    val id: String? = null,
+) : BaseComponentProperty.StringComponentProperty("currentScreen", currentScreen, id)
+

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/FlowIdentifierProperty.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/FlowIdentifierProperty.kt
@@ -1,0 +1,7 @@
+package com.vini.designsystemsdui.property
+
+class FlowIdentifierProperty(
+    val flow: String,
+    val id: String? = null,
+) : BaseComponentProperty.StringComponentProperty("flow", flow, id)
+

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/RequestUpdateProperty.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/RequestUpdateProperty.kt
@@ -1,0 +1,7 @@
+package com.vini.designsystemsdui.property
+
+class RequestUpdateProperty(
+    val requestUpdate: Boolean,
+    val id: String? = null,
+) : BaseComponentProperty.BooleanComponentProperty("requestUpdate", requestUpdate, id)
+

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/ScreenDataProperty.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/ScreenDataProperty.kt
@@ -1,0 +1,17 @@
+package com.vini.designsystemsdui.property
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class ScreenDataProperty(
+    val screenData: JsonObject,
+    val id: String? = null,
+) {
+    fun build() = buildJsonObject {
+        put("name", "screenData")
+        put("value", screenData)
+        id?.let { put("id", it) }
+    }
+}
+

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/StageIdentifierProperty.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/StageIdentifierProperty.kt
@@ -1,0 +1,7 @@
+package com.vini.designsystemsdui.property
+
+class StageIdentifierProperty(
+    val stage: String,
+    val id: String? = null,
+) : BaseComponentProperty.StringComponentProperty("stage", stage, id)
+

--- a/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/ValidPasswordProperty.kt
+++ b/DesignSystemSdUi/src/main/java/com/vini/designsystemsdui/property/ValidPasswordProperty.kt
@@ -1,0 +1,7 @@
+package com.vini.designsystemsdui.property
+
+class ValidPasswordProperty(
+    val isPasswordValid: Boolean,
+    val id: String? = null,
+) : BaseComponentProperty.BooleanComponentProperty("isPasswordValid", isPasswordValid, id)
+


### PR DESCRIPTION
## Summary
- add divider, google maps, sd-ui, and create password components
- support new flow and password properties

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688daed87eb4832ea1d1d9db4fb8228a